### PR TITLE
:arrow_up: karibbu 3.2.0

### DIFF
--- a/vendor/karibbu/Dockerfile
+++ b/vendor/karibbu/Dockerfile
@@ -2,11 +2,9 @@ FROM rezzza/docker-node:6.9.2
 
 MAINTAINER Sébastien HOUZÉ <sebastien.houze@verylastroom.com>
 
-ENV YARN_VERSION 0.18.0
-ENV FLOW_VERSION=0.37.0
+ENV YARN_VERSION 0.18.1
+ENV FLOW_VERSION=0.37.4
 ENV PATH /home/node/.yarn/bin:$PATH
-ENV SASS_BINARY_PATH=/home/node/node-sass-binding.node
-ENV SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true
 
 COPY flow.patch /tmp/
 
@@ -45,8 +43,6 @@ RUN apk add --no-cache --virtual .base-deps \
 USER node
 
 WORKDIR /home/node
-
-ADD node-sass-binding.node /home/node
 
 RUN mkdir -p ~/.yarn/bin \
     && curl --compressed -o ~/.yarn/bin/yarn -L https://github.com/yarnpkg/yarn/releases/download/v$YARN_VERSION/yarn-$YARN_VERSION.js \


### PR DESCRIPTION
With:
- yarn 0.18.1
- flow 0.37.4

With no more node sass binding.