### PR TITLE
:up: Bump patch rezzza/docker-node:karibbu-5.1.0

### DIFF
--- a/vendor/karibbu/Dockerfile
+++ b/vendor/karibbu/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.1.0-alpine
+FROM node:8.1.2-alpine
 
 MAINTAINER Sébastien HOUZÉ <sebastien.houze@verylastroom.com>
 


### PR DESCRIPTION
With node 8.1.2 inside™